### PR TITLE
Abort progress bar on error to avoid deadlock

### DIFF
--- a/prmaster.go
+++ b/prmaster.go
@@ -277,6 +277,7 @@ outer:
 		}
 		prs, _, err := c.ghClient.PullRequests.List(ctx, "cockroachdb", "cockroach", prOpts)
 		if err != nil {
+			progress.Abort(bar)
 			return nil, err
 		}
 		if len(prs) != 0 {
@@ -285,6 +286,7 @@ outer:
 			commits, _, err := c.ghClient.PullRequests.ListCommits(ctx, "cockroachdb", "cockroach",
 				pr.GetNumber(), nil /* listOptions */)
 			if err != nil {
+				progress.Abort(bar)
 				return nil, err
 			}
 			if len(commits) == 0 {


### PR DESCRIPTION
Without aborting, the deferred call to progress.Wait() just blocks if
one of these github client requests fails (as is likely to happen if you
aren't using a github access token).

Without this change and before I added a personal access token to avoid rate limiting, prmaster would get stuck like this:

```
$ prmaster sync
warning: more than 100 remote branches; some will be omitted
Fetching PR 33 / 202 [======>---------------------------------] 54s remaining
SIGABRT: abort
PC=0x1057ffb m=0 sigcode=0

goroutine 0 [idle]:
runtime.mach_semaphore_wait(0x2903, 0xc400000000, 0x102901a, 0x3a03, 0x0, 0x148c620, 0x7ffeefbff688, 0x10523d3, 0xffffffffffffffff, 0x7ffe00000000, ...)
	/usr/local/go/src/runtime/sys_darwin_amd64.s:540 +0xb
runtime.semasleep1(0xffffffffffffffff, 0x7ffe00000000)
	/usr/local/go/src/runtime/os_darwin.go:438 +0x52
runtime.semasleep.func1()
	/usr/local/go/src/runtime/os_darwin.go:457 +0x33
runtime.semasleep(0xffffffffffffffff, 0x7ffeefbff6f8)
	/usr/local/go/src/runtime/os_darwin.go:456 +0x44
runtime.notesleep(0x148cea8)
	/usr/local/go/src/runtime/lock_sema.go:167 +0xe9
runtime.stoplockedm()
	/usr/local/go/src/runtime/proc.go:2096 +0x8c
runtime.schedule()
	/usr/local/go/src/runtime/proc.go:2488 +0x2da
runtime.park_m(0xc420162c00)
	/usr/local/go/src/runtime/proc.go:2599 +0xb6
runtime.mcall(0x0)
	/usr/local/go/src/runtime/asm_amd64.s:351 +0x5b

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc42034488c)
	/usr/local/go/src/runtime/sema.go:56 +0x39
sync.(*WaitGroup).Wait(0xc420344880)
	/usr/local/go/src/sync/waitgroup.go:129 +0x72
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.(*Progress).Wait(0xc4203371e0)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:158 +0x50
main.loadBranches(0x1334560, 0xc4200140c0, 0xc4201d2000, 0xc420138000, 0x4, 0xc42017a00f, 0xa, 0xc420016240, 0x38, 0x0, ...)
	/Users/alex/go/src/github.com/benesch/prmaster/prmaster.go:280 +0x1128
main.runSync(0x1334560, 0xc4200140c0, 0xc4201d2000, 0xc420138000, 0x4, 0xc42017a00f, 0xa, 0xc420016240, 0x38, 0x0, ...)
	/Users/alex/go/src/github.com/benesch/prmaster/prmaster.go:110 +0x238
main.run(0x1334560, 0xc4200140c0, 0xc4200a4960, 0x0)
	/Users/alex/go/src/github.com/benesch/prmaster/prmaster.go:58 +0x21e
main.main()
	/Users/alex/go/src/github.com/benesch/prmaster/prmaster.go:27 +0x5e

goroutine 5 [syscall, 1 minutes]:
os/signal.signal_recv(0x0)
	/usr/local/go/src/runtime/sigqueue.go:139 +0xa7
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:22 +0x22
created by os/signal.init.0
	/usr/local/go/src/os/signal/signal_unix.go:28 +0x41

goroutine 40 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.(*Progress).serve(0xc4203371e0, 0xc420454000)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress_posix.go:25 +0x21d
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.New
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:88 +0x315

goroutine 69 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.(*Bar).serve(0xc4201276c0, 0xc420344880, 0xc4201d2d80, 0x0)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/bar.go:285 +0x157
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newBar
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/bar.go:128 +0x3e5

goroutine 41 [select, 1 minutes, locked to thread]:
runtime.gopark(0x130fc60, 0x0, 0x12fba51, 0x6, 0x18, 0x1)
	/usr/local/go/src/runtime/proc.go:291 +0x11a
runtime.selectgo(0xc4201b8f50, 0xc42008a420)
	/usr/local/go/src/runtime/select.go:392 +0xe50
runtime.ensureSigM.func1()
	/usr/local/go/src/runtime/signal_unix.go:549 +0x1c6
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:2361 +0x1

goroutine 5287 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer.func1(0x1, 0xc420620ba0, 0xc420649880, 0xc4206498f0)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:182 +0x156
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:177 +0x23f

goroutine 5290 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer.func1(0x1, 0xc420620ba0, 0xc420649b20, 0xc420649b90)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:182 +0x156
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:177 +0x23f

goroutine 5288 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer.func1(0x1, 0xc420620ba0, 0xc420649960, 0xc4206499d0)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:182 +0x156
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:177 +0x23f

goroutine 5289 [select]:
github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer.func1(0x1, 0xc420620ba0, 0xc420649a40, 0xc420649ab0)
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:182 +0x156
created by github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb.newWidthSyncer
	/Users/alex/go/src/github.com/benesch/prmaster/vendor/github.com/vbauerster/mpb/progress.go:177 +0x23f

rax    0xe
rbx    0x148cd60
rcx    0x7ffeefbff628
rdx    0x7ffeefbff6a8
rdi    0x2903
rsi    0x1
rbp    0x7ffeefbff660
rsp    0x7ffeefbff628
r8     0x2
r9     0xc4201b8fc8
r10    0xc4203be0a8
r11    0x286
r12    0xc4201b8f68
r13    0xff
r14    0xff
r15    0xf
rip    0x1057ffb
rflags 0x286
cs     0x7
fs     0x0
gs     0x0
```

Nice tool, by the way!

@benesch 