### PR TITLE
README: add GO111MODULE=off

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CLI PR management for OCD developers.
 ## Usage
 
 ```shell
-$ go get -u github.com/benesch/prmaster
+$ GO111MODULE=off go get -u github.com/benesch/prmaster
 $ prmaster <list|sync>
 ```
 


### PR DESCRIPTION
Without this, the vendor directory is ignored, the latest versions are pulled, and the build fails.